### PR TITLE
Update TestL96.jl with Jacobian Test

### DIFF
--- a/test/TestL96.jl
+++ b/test/TestL96.jl
@@ -2,10 +2,39 @@
 module TestL96
 ##############################################################################################
 using DataAssimilationBenchmarks.DeSolvers, DataAssimilationBenchmarks.L96
+using ForwardDiff
 ##############################################################################################
+"""
+    Jacobian() 
 
+Tests the L96 jacobian function for known behavior with automatic differentiation.
+Returns whether the difference of computed jacobians is within error tolerance for every entry
+"""
 function Jacobian()
+    # dummy time argument
+    t = 0.0
 
+    # forcing parameter
+    F = 8.0
+    dx_params = Dict{String, Array{Float64}}("F" => [F])
+
+    # wrapper function
+    function wrap_dx_dt(x)
+        L96.dx_dt(x, t, dx_params)
+    end
+
+    # model state
+    x = Vector{Float64}(1:40)
+
+    # compute difference between ForwardDiff and L96 calculated jacobians
+    diff = Matrix(ForwardDiff.jacobian(wrap_dx_dt, x) - Matrix(L96.jacobian(x, t, dx_params)))
+
+    # compare within error tolerance for every entry
+    if sum((abs.(diff)) .<= 0.01) == 40*40
+        true
+    else
+        false
+    end
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ end
 
 # test set 2: test L96 model equations for known behavior
 @testset "Lorenz-96" begin
-    #@test TestL96.Jacobian()
+    @test TestL96.Jacobian()
     @test TestL96.EMZerosStep()
     @test TestL96.EMFStep()
 end


### PR DESCRIPTION
This additional test case compares the computed jacobians via the L96 jacobian method and the ForwardDiff jacobian method within an error tolerance of 0.01.