### PR TITLE
Small fixes to JOSS paper references

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -40,7 +40,6 @@ DOI = {10.5194/gmd-15-7641-2022}
   month        = {September},
   year         = {2022},
   publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.2029296},
   url          = {https://github.com/nansencenter/DAPPER},
 }
 

--- a/paper.bib
+++ b/paper.bib
@@ -7,7 +7,7 @@
   pages={1283--1296},
   year={2009},
   publisher={American Meteorological Society},
-	doi={https://doi.org/10.1175/2009BAMS2618.1},
+	doi={10.1175/2009BAMS2618.1},
 }
 
 @Article{grudzien2022fast,
@@ -31,7 +31,7 @@ DOI = {10.5194/gmd-15-7641-2022}
   pages={1--43},
   year={2018},
   publisher={Taylor \& Francis},
-	doi={http://doi.org/10.1080/16000870.2018.1445364},
+	doi={10.1080/16000870.2018.1445364},
 }
 
 @software{dapper,
@@ -73,7 +73,7 @@ DOI = {10.5194/gmd-15-7641-2022}
   author={Asch, M., and Bocquet, M., and Nodet, M.},
   year={2016},
   publisher={SIAM},
-	doi={https://doi.org/10.1137/1.9781611974546},
+	doi={10.1137/1.9781611974546},
 }
 
 @article{carrassi2018data,
@@ -85,7 +85,7 @@ DOI = {10.5194/gmd-15-7641-2022}
   pages={e535},
   year={2018},
   publisher={Wiley Online Library},
-	doi={https://doi.org/10.1002/wcc.535},
+	doi={10.1002/wcc.535},
 }
 
 @book{jazwinski2007stochastic,
@@ -104,7 +104,7 @@ DOI = {10.5194/gmd-15-7641-2022}
   booktitle={Proceedings of the Second Workshop on the LLVM Compiler Infrastructure in HPC},
   pages={1--6},
   year={2015},
-	doi={https://doi.org/10.1145/2833157.2833162},
+	doi={10.1145/2833157.2833162},
 }
 
 @article{kalnay20074denkf,
@@ -116,7 +116,7 @@ DOI = {10.5194/gmd-15-7641-2022}
   pages={758--773},
   year={2007},
   publisher={Taylor \& Francis},
-	doi={https://doi.org/10.1111/j.1600-0870.2007.00261.x}
+	doi={10.1111/j.1600-0870.2007.00261.x}
 }
 
 @article{bezanson2017julia,


### PR DESCRIPTION
This PR fixes some minor issues with the references of the JOSS paper:
* Double URL prefixes when rendering DOIs. The `doi` field in the references must not contain URL prefixes. Therefore, I removed them.
* URL to DAPPER Github repository was not displayed. Therefore, I removed the DOI field for the DAPPER reference, as the DOI field seems to take precedence over the URL field in the JOSS paper renderer.

Feel free to discuss, adapt, or reject my changes.

openjournals/joss-reviews#4129